### PR TITLE
fix(gh): replace gh project item-list with GraphQL in move-state.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@burson.kendrick/claude-gh-task-manager",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Claude Code /task skill — bind AI sessions to GitHub issues and auto-log time + context words",
   "type": "module",
   "license": "MIT",

--- a/scripts/gh/move-state.sh
+++ b/scripts/gh/move-state.sh
@@ -71,15 +71,33 @@ if [[ -z "$OPTION_ID" ]]; then
   exit 1
 fi
 
-# Get the project item ID for this issue
+# Get the project item ID for this issue via GraphQL.
+# Resolves through the issue's projectItems edge — works for user- and org-owned
+# projects without a project number, and avoids the `gh project item-list`
+# pagination cap and CLI flag churn.
 REPO=$(read_config repo)
 OWNER=$(echo "$REPO" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
 
-ITEM_ID=$(gh project item-list --owner "$OWNER" --format json --limit 500 | \
-  python3 -c "import json,sys; d=json.load(sys.stdin); [print(i['id']) for i in d['items'] if i['content'].get('number')==$ISSUE]" | head -1)
+ITEM_ID=$(gh api graphql -f query="
+{
+  repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+    issue(number: $ISSUE) {
+      projectItems(first: 10) { nodes { id project { id } } }
+    }
+  }
+}" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+issue=d.get('data',{}).get('repository',{}).get('issue')
+nodes=(issue or {}).get('projectItems',{}).get('nodes',[])
+for n in nodes:
+    if n.get('project',{}).get('id') == '$PROJECT_ID':
+        print(n['id']); break
+")
 
 if [[ -z "$ITEM_ID" ]]; then
-  echo "Issue #$ISSUE not found in project (owner: $OWNER)"
+  echo "Issue #$ISSUE not found in project (owner: $OWNER, projectId: $PROJECT_ID)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Newer gh CLI versions reject `gh project item-list --owner` without `--number`, breaking [move-state.sh](scripts/gh/move-state.sh) with `project number is required when not running interactively`.
- Port the project-item-ID lookup to the same `repository.issue.projectItems` GraphQL pattern already used in [set-priority.sh](scripts/gh/set-priority.sh) — works for user- and org-owned projects, needs no `projectNumber` config, no pagination cap, no python fragility around CLI flag churn.
- Filter the returned project items by the configured `projectId` so repos linked to multiple projects target the right board.
- Bump 1.0.4 → 1.0.5 (patch — behavior-preserving).

## Test plan

- [x] Smoke-tested against `kburson/options-co-pilot` (project #1, user-owned): moved issue #126 Backlog → Ready → Backlog via patched script. GraphQL field-value query confirms Status updates land.
- [ ] Verify on an org-owned project (no test repo handy — same `repository.issue.projectItems` query is already proven by `set-priority.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)